### PR TITLE
Resolve race conditions

### DIFF
--- a/src/Array.hs
+++ b/src/Array.hs
@@ -198,7 +198,7 @@ copy_par src0 src_offset0 dst0 dst_offset0 len0 = copy_par' src0 src_offset0 dst
       then copy src src_offset dst dst_offset len
       else let !half = len `div` 2
                !(src_l, src_r) = splitAt half src
-               !(dst_l, dst_r) = splitAt (len-half) dst
+               !(dst_l, dst_r) = splitAt half dst
                left = copy_par' src_l 0 dst_l 0 half
                right = copy_par' src_r 0 dst_r 0 (len-half)
            in left `par` right `pseq` append left right
@@ -218,7 +218,7 @@ copy_par_m !src0 src_offset0 !dst0 dst_offset0 !len0 = copy_par_m' src0 src_offs
       else do
            let !half = len `div` 2
                !(src_l, src_r) = splitAt half src
-               !(dst_l, dst_r) = splitAt (len-half) dst
+               !(dst_l, dst_r) = splitAt half dst
            !left_f <- P.spawn_$ copy_par_m' src_l 0 dst_l 0 half
            !right <- copy_par_m' src_r 0 dst_r 0 (len-half)
            !left <- P.get left_f

--- a/src/DpsMergeSort4Par.hs
+++ b/src/DpsMergeSort4Par.hs
@@ -55,8 +55,10 @@ msortInplace src tmp =
         !(tmp1, tmp2)     = splitMid tmpA
         !(tmp3, tmp4)     = splitMid tmpB
         !(((src1', tmp1'), (src2', tmp2')), ((src3', tmp3'), (src4', tmp4')))
-                         = (msortInplace src1 tmp1 .||. msortInplace src2 tmp2) .||.
-                           (msortInplace src3 tmp3 .||. msortInplace src4 tmp4)
+                         = (.||||.) (msortInplace src1 tmp1) (msortInplace src2 tmp2)
+                                    (msortInplace src3 tmp3) (msortInplace src4 tmp4) 
+--                         = (msortInplace src1 tmp1 .||. msortInplace src2 tmp2) .||.
+--                           (msortInplace src3 tmp3 .||. msortInplace src4 tmp4) 
 --                         = tuple4 (msortInplace src1) tmp1 (msortInplace src2) tmp2
 --                                  (msortInplace src3) tmp3 (msortInplace src4) tmp4
         tmpA'            = A.append tmp1' tmp2'

--- a/src/DpsMergeSort4Par.hs
+++ b/src/DpsMergeSort4Par.hs
@@ -55,12 +55,10 @@ msortInplace src tmp =
         !(tmp1, tmp2)     = splitMid tmpA
         !(tmp3, tmp4)     = splitMid tmpB
         !(((src1', tmp1'), (src2', tmp2')), ((src3', tmp3'), (src4', tmp4')))
-                         = (.||||.) (msortInplace src1 tmp1) (msortInplace src2 tmp2)
-                                    (msortInplace src3 tmp3) (msortInplace src4 tmp4) 
---                         = (msortInplace src1 tmp1 .||. msortInplace src2 tmp2) .||.
---                           (msortInplace src3 tmp3 .||. msortInplace src4 tmp4) 
---                         = tuple4 (msortInplace src1) tmp1 (msortInplace src2) tmp2
---                                  (msortInplace src3) tmp3 (msortInplace src4) tmp4
+                         = (msortInplace src1 tmp1 .||. msortInplace src2 tmp2) .||.
+                           (msortInplace src3 tmp3 .||. msortInplace src4 tmp4) 
+--                         = (.||||.) (msortInplace src1 tmp1) (msortInplace src2 tmp2)
+--                                    (msortInplace src3 tmp3) (msortInplace src4 tmp4) 
         tmpA'            = A.append tmp1' tmp2'
         tmpB'            = A.append tmp3' tmp4'
         !((srcA'', tmpA''), (srcB'', tmpB''))

--- a/src/Par.hs
+++ b/src/Par.hs
@@ -123,6 +123,6 @@ a .||. b = (a,b)
 {-@ (.||||.) :: x:a -> y:a -> z:a -> w:a 
                     -> { tup:_ | x == fst (fst tup) && y == snd (fst tup) &&
                                  z == fst (snd tup) && w == snd (snd tup) } @-}
-(.||||.) :: (NFData a) => a -. a -. a -. a -. ((a,a),(a,a))  
+(.||||.) :: a -. a -. a -. a -. ((a,a),(a,a))  
 (.||||.) a b c d = ((a, b), (c, d)) 
 #endif


### PR DESCRIPTION
It turns out that using Control.Monad.Par to implement `(.||.)` resolves the race conditions without being obviously slower than the par/pseq/deepseq version.

I've also introduced a 4-ary parallelism operator, but the gap between array size and SEQSIZE has to be huge for that to make a difference.

This would fix #14.