### PR TITLE
Add missing INLIN(ABL)E in the parallel-merge code

### DIFF
--- a/.github/workflows/build-test-linear.yaml
+++ b/.github/workflows/build-test-linear.yaml
@@ -145,12 +145,14 @@ jobs:
       - name: Make sure benchrunner builds and runs
         run: |
           cabal build benchrunner
-          cabal run benchrunner -- 5 Insertionsort Seq 100
-          cabal run benchrunner -- 5 Mergesort Seq 100
-          cabal run benchrunner -- 5 Mergesort Par 100 +RTS -N2
-          cabal run benchrunner -- 5 "VectorSort Insertionsort" Seq 100
-          cabal run benchrunner -- 5 "VectorSort Mergesort" Seq 100
-          cabal run benchrunner -- 5 "VectorSort Quicksort" Seq 100
-          cabal run benchrunner -- 5 "CSort Insertionsort" Seq 100
-          cabal run benchrunner -- 5 "CSort Mergesort" Seq 100
-          cabal run benchrunner -- 5 "CSort Quicksort" Seq 100
+          cabal run benchrunner -- 5 Insertionsort Seq 1000
+          cabal run benchrunner -- 5 Quicksort Seq 1000
+          cabal run benchrunner -- 5 Mergesort Seq 1000
+          cabal run benchrunner -- 5 Mergesort Par 1000 +RTS -N1
+          cabal run benchrunner -- 5 Mergesort Par 1000 +RTS -N2
+          cabal run benchrunner -- 5 "VectorSort Insertionsort" Seq 1000
+          cabal run benchrunner -- 5 "VectorSort Mergesort" Seq 1000
+          cabal run benchrunner -- 5 "VectorSort Quicksort" Seq 1000
+          cabal run benchrunner -- 5 "CSort Insertionsort" Seq 1000
+          cabal run benchrunner -- 5 "CSort Mergesort" Seq 1000
+          cabal run benchrunner -- 5 "CSort Quicksort" Seq 1000

--- a/src/Array.hs
+++ b/src/Array.hs
@@ -179,6 +179,7 @@ generate_loop arr idx end f =
 copy2_par :: HasPrim a =>  Int -> Int -> Int -> Array a -. Array a -. (Array a, Array a)
 copy2_par src_offset0 dst_offset0 len0 =
   Unsafe.toLinear (\src0 ->  Unsafe.toLinear (\dst0 -> (src0, copy_par src0 src_offset0 dst0 dst_offset0 len0)))
+{-# INLINABLE copy2_par #-}
 
 --TODO: src_offset0 and dst_offset0 are not respected.
 {- @ ignore copy_par @-}
@@ -205,6 +206,7 @@ copy_par src0 src_offset0 dst0 dst_offset0 len0 = copy_par' src0 src_offset0 dst
 #else
 copy_par src0 src_offset0 dst0 dst_offset0 len0 = copy src0 src_offset0 dst0 dst_offset0 len0
 #endif
+{-# INLINABLE copy_par #-}
 
 --TODO: src_offset0 and dst_offset0 are not respected.
 {-@ ignore copy_par_m @-}
@@ -223,6 +225,7 @@ copy_par_m !src0 src_offset0 !dst0 dst_offset0 !len0 = copy_par_m' src0 src_offs
            !right <- copy_par_m' src_r 0 dst_r 0 (len-half)
            !left <- P.get left_f
            pure $ append left right
+{-# INLINABLE copy_par_m #-}
 
 -- {-@ ignore foldl1_par @-}
 -- foldl1_par :: Int -> (a -> a -> a) -> a -> Array a -> a

--- a/src/Array/Mutable.hs
+++ b/src/Array/Mutable.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MagicHash        #-}
 {-# LANGUAGE BangPatterns     #-}
 
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 -- The Strict pragma is not just for performance, it's necessary for correctness.
 -- Without it, this implementation contains a bug related to some thunk/effect
@@ -146,8 +147,8 @@ splitAt m = Unsafe.toLinear (\xs -> (slice xs 0 m, slice xs m (size xs)))
 append :: Array a -. Array a -. Array a
 append xs ys =
   let !res = Unsafe.toLinear (\xs -> case xs of
-        (Array l1 _r1 !a1) -> Unsafe.toLinear (\ys -> case ys of
-          (Array _l2 r2 _a2) -> Array l1 r2 a1)) xs ys
+        (Array !l1 _r1 !a1) -> Unsafe.toLinear (\ys -> case ys of
+          (Array _l2 !r2 _a2) -> Array l1 r2 a1)) xs ys
   in res
 
 -- token xs == token ys

--- a/src/DpsMergeSort4Par.hs
+++ b/src/DpsMergeSort4Par.hs
@@ -1,18 +1,23 @@
 
 {-# LANGUAGE CPP #-}
 
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
 module DpsMergeSort4Par where
 
 import qualified Language.Haskell.Liquid.Bag as B
 import           Language.Haskell.Liquid.ProofCombinators hiding ((?))
 import           ProofCombinators
+
+import           Properties.Equivalence
+import           Properties.Order
+import           Par
+
 import           Array as A
 import           ArrayOperations
+
 import           DpsMergePar
 import qualified DpsMergeSort4 as Seq
-import Properties.Equivalence
-import Properties.Order
-import           Par
 
 import           Linear.Common
 #ifdef MUTABLE_ARRAYS
@@ -43,35 +48,52 @@ msortInplace :: (Show a, HasPrimOrd a, NFData a) =>
 msortInplace :: (Show a, HasPrimOrd a) =>
 #endif
   A.Array a -. A.Array a -. (A.Array a, A.Array a)
-msortInplace src tmp =
-  let !(Ur len, src') = A.size2 src in
-  if len <= SEQSIZE
-  then Seq.msortInplace src' tmp
-  else
-    let !(srcA, srcB)     = splitMid src'
-        !(tmpA, tmpB)     = splitMid tmp
-        !(src1, src2)     = splitMid srcA
-        !(src3, src4)     = splitMid srcB
-        !(tmp1, tmp2)     = splitMid tmpA
-        !(tmp3, tmp4)     = splitMid tmpB
-        !(((src1', tmp1'), (src2', tmp2')), ((src3', tmp3'), (src4', tmp4')))
-                         = (msortInplace src1 tmp1 .||. msortInplace src2 tmp2) .||.
-                           (msortInplace src3 tmp3 .||. msortInplace src4 tmp4) 
---                         = (.||||.) (msortInplace src1 tmp1) (msortInplace src2 tmp2)
---                                    (msortInplace src3 tmp3) (msortInplace src4 tmp4) 
-        tmpA'            = A.append tmp1' tmp2'
-        tmpB'            = A.append tmp3' tmp4'
-        !((srcA'', tmpA''), (srcB'', tmpB''))
-                         = merge_par src1' src2' tmpA' .||. merge_par src3' src4' tmpB'
---                         = tuple2 (merge_par src1' src2') tmpA' (merge_par src3' src4') tmpB'
-        src''            = A.append srcA'' srcB''
-        !(tmp''', src''') = merge_par tmpA'' tmpB'' src''
-    in  (src''', tmp''') ? lem_toBag_splitMid src
-                         ? lem_toBag_splitMid tmp
-                         ? lem_toBag_splitMid srcA
-                         ? lem_toBag_splitMid srcB
-                         ? lem_toBag_splitMid tmpA
-                         ? lem_toBag_splitMid tmpB
+msortInplace src tmp = go src tmp where
+  {-@ go :: xs:Array a
+        -> { ys:(Array a ) | A.size ys  == A.size xs   && left xs == left ys &&
+                             right xs == right ys }
+        -> (Array a, Array a)<{\zs ts -> toBag xs == toBag zs && isSorted' zs &&
+                                         token xs == token zs && token ys == token ts &&
+                                         A.size xs == A.size zs && A.size ys == A.size ts &&
+                                         left zs == left xs && right zs == right xs &&
+                                         left ts == left ys && right ts == right ys }>
+         / [A.size xs] @-}
+#ifdef MUTABLE_ARRAYS
+  go :: (Show a, HasPrimOrd a, NFData a) =>
+#else
+  go :: (Show a, HasPrimOrd a) =>
+#endif
+    A.Array a -. A.Array a -. (A.Array a, A.Array a)
+  go src tmp =
+    let !(Ur len, src') = A.size2 src in
+    if len <= SEQSIZE
+    then Seq.msortInplace src' tmp
+    else
+      let !(srcA, srcB)     = splitMid src'
+          !(tmpA, tmpB)     = splitMid tmp
+          !(src1, src2)     = splitMid srcA
+          !(src3, src4)     = splitMid srcB
+          !(tmp1, tmp2)     = splitMid tmpA
+          !(tmp3, tmp4)     = splitMid tmpB
+          !(((src1', tmp1'), (src2', tmp2')), ((src3', tmp3'), (src4', tmp4')))
+                           = (go src1 tmp1 .||. go src2 tmp2) .||.
+                             (go src3 tmp3 .||. go src4 tmp4)
+  --                         = (.||||.) (go src1 tmp1) (go src2 tmp2)
+  --                                    (go src3 tmp3) (go src4 tmp4)
+          tmpA'            = A.append tmp1' tmp2'
+          tmpB'            = A.append tmp3' tmp4'
+          !((srcA'', tmpA''), (srcB'', tmpB''))
+                           = merge_par src1' src2' tmpA' .||. merge_par src3' src4' tmpB'
+  --                         = tuple2 (merge_par src1' src2') tmpA' (merge_par src3' src4') tmpB'
+          src''            = A.append srcA'' srcB''
+          !(tmp''', src''') = merge_par tmpA'' tmpB'' src''
+      in  (src''', tmp''') ? lem_toBag_splitMid src
+                           ? lem_toBag_splitMid tmp
+                           ? lem_toBag_splitMid srcA
+                           ? lem_toBag_splitMid srcB
+                           ? lem_toBag_splitMid tmpA
+                           ? lem_toBag_splitMid tmpB
+{-# INLINE msortInplace #-}
 
 {-@ msort' :: y:a
            -> { xs:(Array a) | A.size xs > 0 && left xs == 0 && right xs == size xs && y == A.get xs 0 }
@@ -87,6 +109,7 @@ msort' anyVal src =
   let !(Ur len, src') = A.size2 src
       !(src'', _tmp) = msortInplace src' (A.make len anyVal) in
   case A.free _tmp of !() -> src''
+{-# INLINE msort' #-}
 
 -- finally, the top-level merge sort function
 {-@ msort :: { xs:(A.Array a) | left xs == 0 && right xs == size xs }
@@ -102,3 +125,4 @@ msort src =
   let !(Ur len, src') = A.size2 src in
       if len == 0 then src'
       else let !(Ur x0, src'') = A.get2 0 src' in msort' x0 src''
+{-# INLINABLE msort #-}


### PR DESCRIPTION
Depends-on: https://github.com/michaelborkowski/lh-array-sort-new/pull/18

If manually remove `toLinear`, these are numbers I'm seeing on 8 physical CPUs:

```
❯ cabal run benchrunner -- 10 "Mergesort" Seq 1000000 2>/dev/null | grep SELFTIMED
SELFTIMED: 0.206165608

❯ cabal run benchrunner -- 10 "Mergesort" Par 1000000 2>/dev/null | grep SELFTIMED
SELFTIMED: 0.256841832

❯ cabal run benchrunner -- 10 "Mergesort" Par 1000000 +RTS -N8 2>/dev/null | grep SELFTIMED
SELFTIMED: 0.189847072
```