### PR TITLE
add simplest possible shell.nix to get ghc-9.10, cabal and z3

### DIFF
--- a/.github/workflows/test-nix-shell.yml
+++ b/.github/workflows/test-nix-shell.yml
@@ -1,0 +1,27 @@
+name: Test shell.nix
+
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths-ignore:
+      - "**/README.md"
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - "**/README.md"
+  workflow_dispatch:
+
+jobs:
+  test-nix-shell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:nixos-25.05
+    - run: nix-shell --run "cabal update && cabal build --dry-run lh-array-sort"

--- a/shell.nix
+++ b/shell.nix
@@ -1,20 +1,9 @@
-let
-  pkgs = import (builtins.fetchGit {
-                   name = "nixos-git";
-                   url = "https://github.com/nixos/nixpkgs/";
-                   ref = "refs/heads/master";
-                   # Commit hash for nixos-unstable as of 2021-12-01
-                   # # rev = "8b01281b66cba818abea8dbbdb3614b1b38961e3";
-                   rev = "c610be58c0b6484c18728dc3ed60310cdbfbd456";
-                 }) {};
-  ghc = pkgs.haskell.compiler.ghc8107;
-  ghc901 = pkgs.haskell.compiler.ghc901;
-  stdenv = pkgs.overrideCC pkgs.stdenv pkgs.gcc7;
-  gcc = pkgs.gcc7;
-in
-  with pkgs;
-  stdenv.mkDerivation {
-    name = "lh-array-sort";
-    buildInputs = [ ghc ghc901 cabal-install stack ghcid z3 numactl
-                    stdenv gcc gdb uthash ];
-  }
+{ compiler ? "ghc910", pkgs ? import <nixpkgs> {}, ... }: # don't pint nixpkgs for now as this is a trivial shell file
+pkgs.mkShell {
+  name = "haskell-shell";
+  buildInputs = [
+    pkgs.haskell.compiler.${compiler}
+    pkgs.haskellPackages.cabal-install # have to use default cabal instead of ${compiler}'s one to hit nix cache
+    pkgs.z3
+    ];
+}


### PR DESCRIPTION
this is a trivial support for nix-shell that fetches ghc/cabal/z3 from nixpkgs. There's no point in pinning nixpkgs with such a minimal setup. A comprehensive nix shell that also provides haskell dependencies is drafted here: 

- https://github.com/michaelborkowski/lh-array-sort-new/tree/artem/full-nix

but it can't go until nixpkgs fully adopt ghc-9.10:

- https://github.com/NixOS/nixpkgs/pull/429810

(or at least until they get liquid stuff work with their ghc-9.10 package set).