### PR TITLE
allow to build with GHC 9.10.3

### DIFF
--- a/.github/workflows/test-nix-shell.yml
+++ b/.github/workflows/test-nix-shell.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v25
+    - uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-25.05
-    - run: nix-shell --run "cabal update && cabal build --dry-run lh-array-sort"
+        nix_path: nixpkgs=channel:nixos-25.11
+    - run: nix-shell --run "cabal update && cabal build --dry-run benchrunner"

--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,15 @@ packages: .
 
 with-compiler: ghc
 
+allow-newer:
+    -- this is akward: the single version of `liquidhaskell` we're compatible with depends on a particular
+    -- version of `bytestring` (to a point release! for no good reason!), which makes it impossible
+    -- to bump ghc 9.10.1 -> 9.10.3, and this, in turn, is inconvenient where a system-provided GHC
+    -- is preferable for various reasons (e.g. in nix-shell, where you only hit the binary cache if you
+    -- let nix choose the minor release, i.e. the x in 9.10.x)
+    -- upstream issue: https://github.com/ucsd-progsys/liquidhaskell/issues/2679
+    liquidhaskell:bytestring
+
 package lh-array-sort
     ghc-options: -O2
     -- ghc-options: -ddump-simpl -ddump-to-file -dsuppress-all


### PR DESCRIPTION
Before we could only have 9.10.1 (maybe 9.10.2) because the version of `liquidhaskell` we depend on is too strict about the version of `bytestring` (a boot library) it wants, see https://github.com/ucsd-progsys/liquidhaskell/issues/2679