### PR TITLE
PrimUnlifted.hs (prim arrays): fix size# and fill#

### DIFF
--- a/src/Array/Mutable/PrimUnlifted.hs
+++ b/src/Array/Mutable/PrimUnlifted.hs
@@ -2,11 +2,13 @@
 {-# LANGUAGE UnboxedTuples    #-}
 {-# LANGUAGE MagicHash        #-}
 {-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 
 module Array.Mutable.PrimUnlifted where
 
 import qualified GHC.Exts as GHC
+import qualified GHC.Base as GHC
 import qualified Data.Primitive.Types as P
 
 --------------------------------------------------------------------------------
@@ -27,7 +29,7 @@ make# len elt =
 {-# INLINABLE fill# #-}
 fill# :: P.Prim a => GHC.MutableByteArray# GHC.RealWorld -> GHC.Int# -> a -> GHC.MutableByteArray# GHC.RealWorld
 fill# arr len elt =
-  case GHC.runRW# (P.setByteArray# arr 0# (len GHC.-# 1#) elt) of
+  case GHC.runRW# (P.setByteArray# arr 0# len elt) of
     _ -> arr
 
 {-# INLINABLE makeNoFill# #-}
@@ -61,7 +63,7 @@ copy# elt (Array# !src) src_offset (Array# !dst) dst_offset n =
     n_bytes          = (P.sizeOf# elt) GHC.*# n
 
 {-# INLINABLE size# #-}
-size# :: Array# a -> GHC.Int#
+size# :: forall a. P.Prim a => Array# a -> GHC.Int#
 size# (Array# arr) =
   case GHC.runRW# (GHC.getSizeofMutableByteArray# arr) of
-    (# _, !sz #) -> sz
+    (# _, sz #) -> sz `GHC.divInt#` (P.sizeOf# (undefined :: a))


### PR DESCRIPTION
Currently:

```shellsession
$ cabal repl lh-array-sort -f+prim-mutable-arrays
λ> import qualified Array as A
λ> a=A.make 3 42 :: A.Array Int
λ> a
Array { lower = 0, upper = 3, arr = [42,42,140031122112928,140031122112816,283482722592,283482722624,283482722648,25769803776,0,4509103997124609,641341291439128576,108650440555560960,140031122082664,8589934593,140031120662243,283482687433,283482679866,140031122082664,4294967297,140031120340082,283482687466,140031105932936,283482679921,283482687489]
```

Note two issues: (1) only 2 instead of 3 copies of 42 are printed; (2) after the 42s, we print some garbage. The reasons are as follows and fixed in this patch.

## (1) `fill#` has an one-off error

we used to do `size - 1` in `fill#` but we should do `size`.

## (2) `size#` counts in bytes

The reason for the garbage you see is that the `Show` instances (transitively, through `toList#`) uses `Array.Mutable.PrimUnlifted.size#` to count, which is supposed to count in elements but instewad returns the number of bytes. 

https://github.com/michaelborkowski/lh-array-sort-new/blob/c062846bb136cd419a81235276bfe5b9c826c903/src/Array/Mutable.hs#L58-L65

https://github.com/michaelborkowski/lh-array-sort-new/blob/c062846bb136cd419a81235276bfe5b9c826c903/src/Array/Mutable.hs#L184-L187