### PR TITLE
Towards a faster mergesort

### DIFF
--- a/src/Array/Mutable.hs
+++ b/src/Array/Mutable.hs
@@ -19,6 +19,8 @@ in [linear-base](https://github.com/tweag/linear-base).
 -}
 module Array.Mutable where
 
+import Data.Bits (unsafeShiftL, unsafeShiftR, (.&.), (.|.))
+
 import           Linear.Common
 import qualified Unsafe.Linear as Unsafe
 import           Control.DeepSeq ( NFData(..) )
@@ -47,128 +49,147 @@ type HasPrim a =
   Unconstrained a
 #endif
 
-{-@ data Array a = Array { left :: _, right :: _, arr :: _ } @-}
+{-# INLINE pack #-}
+pack :: Int -> Int -> Int -- (lower, size) -> packed
+pack lower size = (lower `unsafeShiftL` 32) .|. (size .&. 0xFFFFFFFF)
 
-data Array a = Array { lower :: {-# UNPACK #-} !Int
-                     , upper :: {-# UNPACK #-} !Int
-                     , array ::                !(Array# a)
+{-# INLINE lowerOf #-}
+lowerOf :: Int -> Int
+lowerOf p = (p `unsafeShiftR` 32) .&. 0xFFFFFFFF
+
+{-# INLINE sizeOf #-}
+sizeOf :: Int -> Int
+sizeOf  p = p .&. 0xFFFFFFFF
+
+{-# INLINE upperOf #-}
+upperOf :: Int -> Int
+upperOf p = lowerOf p + sizeOf p
+
+data Array a = Array { packed :: {-# UNPACK #-} !Int
+                     , array  ::                !(Array# a)
                      }
-
 
 #ifdef PRIM_MUTABLE_ARRAYS
 instance (Show a, P.Prim a) => Show (Array a) where
 #else
 instance Show a => Show (Array a) where
 #endif
-  show (Array l r arr) =
-    "Array { lower = " ++ show l ++ ", upper = " ++ show r ++ ", arr = " ++
+  show (Array p arr) =
+    "Array { lower = " ++ show (lowerOf p) ++ ", size = " ++ show (sizeOf p) ++ ", arr = " ++
     (show $ toList# arr)
 
 instance NFData a => NFData (Array a) where
-  rnf (Array lo hi _arr) = rnf lo `seq` rnf hi `seq` ()
+  rnf (Array p _arr) = rnf p `seq` ()
 
 {-# INLINABLE make #-}
 make :: HasPrim a => Int -> a -> Array a
-make 0 _ = Array 0 0 undefined
-make s0@(GHC.I# s) x = Array 0 s0 (make# s x)
+make 0 _ = Array 0 undefined
+make s0@(GHC.I# s) x = Array (pack 0 s0) (make# s x)
 
 {-# INLINABLE makeNoFill #-}
 makeNoFill :: HasPrim a => Int -> a -> Array a
 makeNoFill s0@(GHC.I# s) x =
-  Array 0 s0
+  Array (pack 0 s0)
 #ifdef PRIM_MUTABLE_ARRAYS
   (makeNoFill# s x)
 #else
   (make# s x)
 #endif
 
-{-# INLINABLE size #-}
+{-# INLINE size #-}
 size :: Array a -> Int
-size (Array !lo !hi _arr) = hi-lo
+size (Array !p _arr) = sizeOf p
 
-{-# INLINABLE get #-}
+{-# INLINE get #-}
 get :: HasPrim a => Array a -> Int -> a
-get (Array lo'@(GHC.I# lo) _hi !arr) i'@(GHC.I# i) =
+get (Array !p !arr) i'@(GHC.I# i) =
   seq
 #ifdef RUNTIME_CHECKS
-  ( if i' < 0 || i' >= (_hi - lo')
-    then (error $ "get: index out of bounds: i = " ++ show i' ++ ", relative to " ++ show lo' ++ "," ++ show _hi)
+  ( if i' < 0 || i' >= (sizeOf p)
+    then (error $ "get: index out of bounds: i = " ++ show i' ++ 
+                    ", relative to " ++ show (lowerOf p) ++ "," ++ show (upperOf p))
     else () )
 #else
   ()
 #endif
-  get# arr (lo GHC.+# i)
+  (let (GHC.I# lo) = lowerOf p in 
+      get# arr (lo GHC.+# i))
 
-{-# INLINABLE set #-}
+{-# INLINE set #-}
 set :: HasPrim a => Array a -> Int -> a -> Array a
-set (Array lo'@(GHC.I# lo) hi !arr) i'@(GHC.I# i) !a =
+set (Array !p !arr) i'@(GHC.I# i) !a =
   seq
 #ifdef RUNTIME_CHECKS
   ( if i' < 0 || i' >= (hi - lo')
-    then (error $ "set: index out of bounds: i = " ++ show i' ++ ", relative to " ++ show lo' ++ "," ++ show hi)
+    then (error $ "set: index out of bounds: i = " ++ show i' ++ 
+                    ", relative to " ++ show (lowerOf p) ++ "," ++ show (upperOf p))
     else () )
 #else
   ()
 #endif
-  Array (GHC.I# lo) hi (set# arr (lo GHC.+# i) a)
+  (let (GHC.I# lo) = lowerOf p in 
+      Array p (set# arr (lo GHC.+# i) a))
 
-{-# INLINABLE copy #-}
+{-# INLINE copy #-}
 copy :: HasPrim a => Array a -> Int -> Array a -> Int -> Int -> Array a
-copy s@(Array (GHC.I# lo1) _hi1 src) (GHC.I# src_offset)
-     d@(Array (GHC.I# lo2) _hi2 dst) (GHC.I# dst_offset)
+copy s@(Array p1 src) (GHC.I# src_offset)
+     d@(Array p2 dst) (GHC.I# dst_offset)
      (GHC.I# n) =
+  let (GHC.I# lo1) = lowerOf p1
+      (GHC.I# lo2) = lowerOf p2 in
 #ifdef PRIM_MUTABLE_ARRAYS
-  case copy# (get# src lo1) src (lo1 GHC.+# src_offset) dst (lo2 GHC.+# dst_offset) n of
-    dst_arr' -> d { array = dst_arr' }
+    case copy# (get# src lo1) src (lo1 GHC.+# src_offset) dst (lo2 GHC.+# dst_offset) n of
+        dst_arr' -> d { array = dst_arr' }
 #else
-  case copy#                src (lo1 GHC.+# src_offset) dst (lo2 GHC.+# dst_offset) n of
-    dst_arr' -> d { array = dst_arr' }
+    case copy#                src (lo1 GHC.+# src_offset) dst (lo2 GHC.+# dst_offset) n of
+        dst_arr' -> d { array = dst_arr' }
 #endif
 
 
-{-# INLINABLE copy2 #-}
+{-# INLINE copy2 #-}
 copy2 :: HasPrim a => Int -> Int -> Int -> (Array a -. (Array a -. (Array a, Array a)))
 copy2 xi yi n = Unsafe.toLinear (\xs -> Unsafe.toLinear (\ys -> (xs, copy xs xi ys yi n)))
 
-{-# INLINABLE slice #-}
+{-# INLINE slice #-}
 slice :: Array a -> Int -> Int -> Array a
-slice (Array l _r !a) l' r' = Array (l+l') (l+r') a
+slice (Array !p !a) l' r' = 
+    Array (pack ((lowerOf p)+l') (r'-l')) a
 
-{-# INLINABLE slice2 #-}
+{-# INLINE slice2 #-}
 slice2 :: Array a -> Int -> Int -> (Array a, Array a)
 slice2 !ar l' r' = (slice ar l' r', ar)
 
-{-# INLINABLE splitAt #-}
+{-# INLINE splitAt #-}
 splitAt :: Int -> (Array a -. (Array a, Array a))
 splitAt m = Unsafe.toLinear (\xs -> (slice xs 0 m, slice xs m (size xs)))
 
-{-# INLINABLE append #-}
+{-# INLINE append #-}
 -- PRE-CONDITION: the two slices are backed by the same array and should be contiguous.
 append :: Array a -. Array a -. Array a
 append xs ys =
   let !res = Unsafe.toLinear (\xs -> case xs of
-        (Array !l1 _r1 !a1) -> Unsafe.toLinear (\ys -> case ys of
-          (Array _l2 !r2 _a2) -> Array l1 r2 a1)) xs ys
+        (Array !p1 !a1) -> Unsafe.toLinear (\ys -> case ys of
+          (Array !p2 _a2) -> Array (pack (lowerOf p1) (sizeOf p1 + sizeOf p2)) a1)) xs ys
   in res
 
 -- token xs == token ys
 -- lem_slice_append :: Array a -> Array a -> ()
 -- lem_slice_append xs ys  = ()
 
-{-# INLINABLE size2 #-}
+{-# INLINE size2 #-}
 size2 :: Array a -. (Ur Int, Array a)
 size2 = Unsafe.toLinear (\ar -> (Ur (size ar), ar))
 
-{-# INLINABLE get2 #-}
+{-# INLINE get2 #-}
 get2 :: HasPrim a => Int -> (Array a -. (Ur a, Array a))
 get2 i = Unsafe.toLinear (\ar -> (Ur (get ar i), ar))
 
-{-# INLINABLE setLin #-}
+{-# INLINE setLin #-}
 setLin :: HasPrim a => Int -> a -> (Array a -. Array a)
 setLin n y = Unsafe.toLinear (\ar -> set ar n y)
 
 fromList :: HasPrim a => [a] -> Array a
-fromList [] = Array 0 0 undefined
+fromList [] = Array 0 undefined
 fromList ls =
   let a0 = make (length ls) (head ls)
   in foldl (\acc (i,x) -> set acc i x) a0 (zip [0..] ls)

--- a/src/Array/Mutable/PrimUnlifted.hs
+++ b/src/Array/Mutable/PrimUnlifted.hs
@@ -40,19 +40,19 @@ makeNoFill# len elt =
   where
     nbytes = (P.sizeOf# elt) GHC.*# len
 
-{-# INLINABLE get# #-}
+{-# INLINE get# #-}
 get# :: P.Prim a => Array# a -> GHC.Int# -> a
 get# (Array# !arr) i =
   case GHC.runRW# (P.readByteArray# arr i) of
     (# _, !ret #) -> ret
 
-{-# INLINABLE set# #-}
+{-# INLINE set# #-}
 set# :: P.Prim a => Array# a -> GHC.Int# -> a -> Array# a
 set# (Array# !arr) i !a =
   case GHC.runRW# (P.writeByteArray# arr i a) of
     _ -> Array# arr
 
-{-# INLINABLE copy# #-}
+{-# INLINE copy# #-}
 copy# :: P.Prim a => a -> Array# a -> GHC.Int# -> Array# a -> GHC.Int# -> GHC.Int# -> Array# a
 copy# elt (Array# !src) src_offset (Array# !dst) dst_offset n =
   case GHC.runRW# (GHC.copyMutableByteArray# src src_offset_bytes dst dst_offset_bytes n_bytes) of
@@ -62,7 +62,7 @@ copy# elt (Array# !src) src_offset (Array# !dst) dst_offset n =
     dst_offset_bytes = (P.sizeOf# elt) GHC.*# dst_offset
     n_bytes          = (P.sizeOf# elt) GHC.*# n
 
-{-# INLINABLE size# #-}
+{-# INLINE size# #-}
 size# :: forall a. P.Prim a => Array# a -> GHC.Int#
 size# (Array# arr) =
   case GHC.runRW# (GHC.getSizeofMutableByteArray# arr) of

--- a/src/DpsMerge.hs
+++ b/src/DpsMerge.hs
@@ -45,86 +45,84 @@ merge' :: HasPrimOrd a =>
   Int -> Int -> Int ->
   A.Array a -. A.Array a -. A.Array a -.
   (A.Array a, A.Array a)
-merge' i1 i2 j !src1 !src2 !dst = go i1 i2 j src1 src2 dst where
-  {-@ go :: i1:Nat -> i2:Nat
-             -> { j:Nat  | i1 + i2 == j }
-
-             -> { xs1:(Array a) | isSorted' xs1 && i1 <= size xs1 }
-             -> { xs2:(Array a) | isSorted' xs2 && token xs1 == token xs2 && right xs1 == left xs2 && i2 <= size xs2 }
-             -> {  zs:(Array a) | size xs1 + size xs2 == size zs &&
-
-                                  j <= size zs &&
-                                  isSortedBtw zs 0 j &&
-                                  B.union (toBagBtw xs1 0 i1) (toBagBtw xs2 0 i2) == toBagBtw zs 0 j &&
-                                  ( j == 0 || i1 == size xs1 || A.get xs1 i1 >= A.get zs (j-1) ) &&
-                                  ( j == 0 || i2 == size xs2 || A.get xs2 i2 >= A.get zs (j-1) ) }
-
-             -> { t:_    | B.union (toBag xs1) (toBag xs2) == toBag (snd t)  &&
-                           toSlice zs 0 j == toSlice (snd t) 0 j &&
-                           isSorted' (snd t) &&
-                           fst t == A.append xs1 xs2 &&
-                           token xs1 == token (fst t) &&
-                           size (snd t) == size zs && token (snd t) == token zs &&
-                           left (snd t) == left zs && right (snd t) == right zs  } / [size zs - j] @-}
-  go :: HasPrimOrd a =>
-        Int -> Int -> Int ->
-        A.Array a -. A.Array a -. A.Array a -.
-        (A.Array a, A.Array a)
-  go i1 i2 j !src1 !src2 !dst =
-    let !(Ur len1, !src1') = A.size2 src1
-        !(Ur len2, !src2') = A.size2 src2 in
-    if i1 >= len1
-    then
-      let !(src2'1, dst') = A.copy2 i2 j (len2-i2) src2' dst in (A.append src1' src2'1, dst')
-              {- equivalence -}     ? lem_toBagBtw_compose' src1 0 i1 len1
-                                    ? lem_toBagBtw_compose' src2 0 i2 len2
-                                    ? lem_toBagBtw_compose' dst' 0 j  (A.size dst')
-                                    ? lem_equal_slice_bag   dst   dst' 0 (j
-                                        ? lem_copy_equal_slice  src2' i2 dst j (len2-i2) )
-                                    ? lem_equal_slice_bag'  src2' dst' i2 len2 j (A.size dst')
-              {- sortedness -}      ? lem_isSorted_copy src2' i2 dst j (len2-i2)
-    else if i2 >= len2
-    then
-      let !(src1'1, dst') = A.copy2 i1 j (len1-i1) src1' dst in (A.append src1'1 src2', dst')
-              {- equivalence -}     ? lem_toBagBtw_compose' src1 0 i1 len1
-                                    ? lem_toBagBtw_compose' src2 0 i2 len2
-                                    ? lem_toBagBtw_compose' dst' 0 j  (A.size dst')
-                                    ? lem_equal_slice_bag   dst   dst' 0 (j
-                                        ? lem_copy_equal_slice  src1' i1 dst j (len1-i1) )
-                                    ? lem_equal_slice_bag'  src1' dst'  i1 len1 j (A.size dst')
-              {- sortedness -}      ? lem_isSorted_copy src1' i1 dst j (len1-i1)
-    else
-      let !(Ur v1, src1'1) = A.get2 i1 src1'
-          !(Ur v2, src2'1) = A.get2 i2 src2' in
-      if v1 < v2
-      then let dst' = A.setLin j v1 dst
-               !(src'', dst'') =  go (i1 + 1) i2 (j + 1
-                      {- eq -}          ? lem_toBagBtw_right src1 0 (i1+1)
-                                        ? lem_bag_union v1 (toBagBtw src1 0 i1) (toBagBtw src2 0 i2)
-                                        ? lem_equal_slice_bag    dst dst'   0 (j
-                                            ? lem_toSlice_set    dst     j v1)
-                                        ? lma_gs dst j v1
-                                        ? lem_toBagBtw_right dst' 0 (j+1)
-                      {- sor -}         ? lem_isSortedBtw_narrow src1 0 i1 len1 len1
-                                        ? lem_equal_slice_sorted dst   dst'  0 0 j j
-                                        ? lem_isSortedBtw_build_right  dst'  0 (j
-                                              ? if j > 0 then lma_gns dst   j (j-1) v1 else ())
-                                   ) src1'1 src2'1 dst' in
-           (src'', dst'') ? lem_equal_slice_narrow dst' dst'' 0 0 j (j+1)
-      else let dst' = A.setLin j v2 dst
-               !(src'', dst'') =  go i1 (i2 + 1) (j + 1
-                                        ? lem_toBagBtw_right src2 0 (i2+1)
-                                        ? lem_bag_union v2 (toBagBtw src1 0 i1) (toBagBtw src2 0 i2)
-                                        ? lem_equal_slice_bag    dst dst'   0 (j
-                                            ? lem_toSlice_set    dst     j v2)
-                                        ? lma_gs dst j v2
-                                        ? lem_toBagBtw_right dst' 0 (j+1)
-                      {- sor -}         ? lem_isSortedBtw_narrow src2 0 i2 len2 len2
-                                        ? lem_equal_slice_sorted dst   dst'  0 0 j j
-                                        ? lem_isSortedBtw_build_right  dst'  0 (j
-                                              ? if j > 0 then lma_gns dst   j (j-1) v2 else ())
-                                   ) src1'1 src2'1 dst' in
-           (src'', dst'') ? lem_equal_slice_narrow dst' dst'' 0 0 j (j+1)
+merge' i1 i2 j !src1 !src2 !dst = go i1 i2 j src1' src2' dst     
+  where
+    !(Ur len1, !src1') = A.size2 src1
+    !(Ur len2, !src2') = A.size2 src2
+    {-@ go :: i1:Nat -> i2:Nat
+                -> { j:Nat  | i1 + i2 == j }
+                -> { xs1:(Array a) | isSorted' xs1 && i1 <= size xs1 }
+                -> { xs2:(Array a) | isSorted' xs2 && token xs1 == token xs2 && right xs1 == left xs2 && i2 <= size xs2 }
+                -> {  zs:(Array a) | size xs1 + size xs2 == size zs &&
+                                    j <= size zs &&
+                                    isSortedBtw zs 0 j &&
+                                    B.union (toBagBtw xs1 0 i1) (toBagBtw xs2 0 i2) == toBagBtw zs 0 j &&
+                                    ( j == 0 || i1 == size xs1 || A.get xs1 i1 >= A.get zs (j-1) ) &&
+                                    ( j == 0 || i2 == size xs2 || A.get xs2 i2 >= A.get zs (j-1) ) }
+                -> { t:_    | B.union (toBag xs1) (toBag xs2) == toBag (snd t)  &&
+                            toSlice zs 0 j == toSlice (snd t) 0 j &&
+                            isSorted' (snd t) &&
+                            fst t == A.append xs1 xs2 &&
+                            token xs1 == token (fst t) &&
+                            size (snd t) == size zs && token (snd t) == token zs &&
+                            left (snd t) == left zs && right (snd t) == right zs  } / [size zs - j] @-}
+    go :: HasPrimOrd a =>
+            Int -> Int -> Int ->
+            A.Array a -. A.Array a -. A.Array a -.
+            (A.Array a, A.Array a)
+    go !i1 !i2 !j !src1 !src2 !dst =
+        if i1 >= len1
+        then
+        let !(src2'1, dst') = A.copy2 i2 j (len2-i2) src2 dst in (A.append src1 src2'1, dst')
+                {- equivalence -}     ? lem_toBagBtw_compose' src1 0 i1 len1
+                                        ? lem_toBagBtw_compose' src2 0 i2 len2
+                                        ? lem_toBagBtw_compose' dst' 0 j  (A.size dst')
+                                        ? lem_equal_slice_bag   dst   dst' 0 (j
+                                            ? lem_copy_equal_slice  src2 i2 dst j (len2-i2) )
+                                        ? lem_equal_slice_bag'  src2 dst' i2 len2 j (A.size dst')
+                {- sortedness -}      ? lem_isSorted_copy src2 i2 dst j (len2-i2)
+        else if i2 >= len2
+        then
+        let !(src1'1, dst') = A.copy2 i1 j (len1-i1) src1 dst in (A.append src1'1 src2, dst')
+                {- equivalence -}     ? lem_toBagBtw_compose' src1 0 i1 len1
+                                        ? lem_toBagBtw_compose' src2 0 i2 len2
+                                        ? lem_toBagBtw_compose' dst' 0 j  (A.size dst')
+                                        ? lem_equal_slice_bag   dst   dst' 0 (j
+                                            ? lem_copy_equal_slice  src1 i1 dst j (len1-i1) )
+                                        ? lem_equal_slice_bag'  src1 dst'  i1 len1 j (A.size dst')
+                {- sortedness -}      ? lem_isSorted_copy src1 i1 dst j (len1-i1)
+        else
+        let !(Ur v1, src1'1) = A.get2 i1 src1
+            !(Ur v2, src2'1) = A.get2 i2 src2 in
+        if v1 < v2
+        then let dst' = A.setLin j v1 dst
+                 !(src'', dst'') =  go (i1 + 1) i2 (j + 1
+                        {- eq -}          ? lem_toBagBtw_right src1 0 (i1+1)
+                                            ? lem_bag_union v1 (toBagBtw src1 0 i1) (toBagBtw src2 0 i2)
+                                            ? lem_equal_slice_bag    dst dst'   0 (j
+                                                ? lem_toSlice_set    dst     j v1)
+                                            ? lma_gs dst j v1
+                                            ? lem_toBagBtw_right dst' 0 (j+1)
+                        {- sor -}         ? lem_isSortedBtw_narrow src1 0 i1 len1 len1
+                                            ? lem_equal_slice_sorted dst   dst'  0 0 j j
+                                            ? lem_isSortedBtw_build_right  dst'  0 (j
+                                                ? if j > 0 then lma_gns dst   j (j-1) v1 else ())
+                                    ) src1'1 src2'1 dst' in
+            (src'', dst'') ? lem_equal_slice_narrow dst' dst'' 0 0 j (j+1)
+        else let dst' = A.setLin j v2 dst
+                 !(src'', dst'') =  go i1 (i2 + 1) (j + 1
+                                            ? lem_toBagBtw_right src2 0 (i2+1)
+                                            ? lem_bag_union v2 (toBagBtw src1 0 i1) (toBagBtw src2 0 i2)
+                                            ? lem_equal_slice_bag    dst dst'   0 (j
+                                                ? lem_toSlice_set    dst     j v2)
+                                            ? lma_gs dst j v2
+                                            ? lem_toBagBtw_right dst' 0 (j+1)
+                        {- sor -}         ? lem_isSortedBtw_narrow src2 0 i2 len2 len2
+                                            ? lem_equal_slice_sorted dst   dst'  0 0 j j
+                                            ? lem_isSortedBtw_build_right  dst'  0 (j
+                                                ? if j > 0 then lma_gns dst   j (j-1) v2 else ())
+                                    ) src1'1 src2'1 dst' in
+            (src'', dst'') ? lem_equal_slice_narrow dst' dst'' 0 0 j (j+1)
 {-# INLINE merge' #-}
 
 {-@ merge :: { xs1:(Array a) | isSorted' xs1 }


### PR DESCRIPTION
The work here lowers allocation per sorting run by over half by moving the size calls outside of the merge w/w go function and packing unlifted array bounds into a single int. Still a draft because I'm not sure how much it helps speed as I'm not getting consistent enough time measurements on my laptop.